### PR TITLE
Fix token balance calculation

### DIFF
--- a/src/orca.js
+++ b/src/orca.js
@@ -16,12 +16,10 @@ async function getAllSignatures(poolAddress) {
 }
 
 async function getTokenBalance(mint, owner) {
-  const res = await connection.getTokenAccountsByOwner(owner, { mint });
+  const res = await connection.getParsedTokenAccountsByOwner(owner, { mint });
   let total = 0;
-  for (const acc of res.value) {
-    const data = acc.account.data;
-    const decoded = JSON.parse(Buffer.from(data[0], data[1] === 'base64' ? 'base64' : 'utf8').toString());
-    const amount = parseInt(decoded?.parsed?.info?.tokenAmount?.amount || 0);
+  for (const { account } of res.value) {
+    const amount = parseInt(account.data.parsed.info.tokenAmount.amount);
     total += amount;
   }
   return total;


### PR DESCRIPTION
## Summary
- fetch parsed token account data instead of manually decoding bytes

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688107c8eba08331a26674cd369ed4b1